### PR TITLE
Rsyncable Single Backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,7 @@ __pycache__/
 test/**/logs/
 test/**/data/
 
+test/abackup/.abackup-tmp/
+
 test/abdata/data.yml
 test/absync/sync.yml

--- a/lib/abackup/backup/backup.py
+++ b/lib/abackup/backup/backup.py
@@ -88,7 +88,7 @@ def perform_backup(config: Config, project_name: str, containers: List[Container
         if not skip_backup:
             for command in container.build_database_backup_commands(backup_path):
                 if command.run(log):
-                    os.chmod(command.backup_file, config.file_permissions)
+                    os.chmod(command.backup_file_path, config.file_permissions)
                     remove_backup(container.backup.version_count, backup_path, command.file_prefix,
                                   command.file_extension, log)
                     successful_commands.append(command.friendly_str())
@@ -97,7 +97,7 @@ def perform_backup(config: Config, project_name: str, containers: List[Container
                     failed_commands.append(command.friendly_str())
             for command in container.build_directory_backup_commands(backup_path):
                 if command.run(log):
-                    os.chmod(command.backup_file, config.file_permissions)
+                    os.chmod(command.backup_file_path, config.file_permissions)
                     remove_backup(container.backup.version_count, backup_path, command.file_prefix,
                                   command.file_extension, log)
                     successful_commands.append(command.friendly_str())

--- a/lib/abackup/backup/project.py
+++ b/lib/abackup/backup/project.py
@@ -4,8 +4,8 @@ import yaml
 from typing import Any, Dict, List
 
 from abackup import fs, healthchecks as hc, notifications
-from abackup.docker import Command, DockerCommand, DirectoryBackupCommand, DirectoryRestoreCommand, \
-    MysqlBackupCommand, MysqlRestoreCommand, PostgresBackupCommand, PostgresRestoreCommand
+from abackup.docker import Command, DockerCommand, DirectoryTarBackupCommand, DirectoryTarRestoreCommand, DirectoryTarCommand, \
+    MysqlBackupCommand, MysqlRestoreCommand, PostgresBackupCommand, PostgresRestoreCommand, TarBackupSettings
 
 
 def build_commands(command_input: List[Any], container_name: str):
@@ -166,15 +166,15 @@ class Container:
             self.name, ", ".join([str(d) for d in self.databases]), ", ".join(self.directories),
             self.backup, self.restore)
 
-    def build_directory_backup_commands(self, backup_path: str):
+    def build_directory_backup_commands(self, backup_path: str) -> List[DirectoryTarCommand]:
         if self.backup:
-            return [DirectoryBackupCommand(cdir, backup_path, self.name, self.backup.docker_options)
+            return [DirectoryTarBackupCommand(cdir, backup_path, TarBackupSettings(self.backup.version_count == 1), self.name, self.backup.docker_options)
                     for cdir in self.directories]
         return []
 
-    def build_directory_restore_commands(self, backup_path: str):
+    def build_directory_restore_commands(self, backup_path: str) -> List[DirectoryTarCommand]:
         if self.restore:
-            return [DirectoryRestoreCommand(cdir, backup_path, self.name, self.restore.docker_options)
+            return [DirectoryTarRestoreCommand(cdir, backup_path, TarBackupSettings(self.backup.version_count == 1), self.name, self.backup.docker_options)
                     for cdir in self.directories]
         return []
 

--- a/lib/abackup/docker.py
+++ b/lib/abackup/docker.py
@@ -11,6 +11,92 @@ from abackup import Command, fs
 # TODO: look into replacing all the subprocess calls with the python docker library
 
 
+def compress_file(file_path: str, log: logging.Logger):
+    return Command("gzip --force --rsyncable {}".format(file_path)).run(log)
+
+
+def decompress_file(file_path: str, log: logging.Logger):
+    return Command("gzip --decompress {}".format(file_path)).run(log)
+
+
+class BackupFileSettings:
+    def __init__(self, is_single_backup: bool, prefix: str = None, force_timestamp: bool = None, use_compression: bool = True):
+        self.is_single_backup = is_single_backup
+        self.prefix = prefix
+        self.force_timestamp = force_timestamp
+        self.use_compression = use_compression
+
+    @property
+    def use_identifier_as_perfix(self):
+        return self.prefix is None
+
+    @property
+    def use_timestamp(self):
+        return self.force_timestamp or not self.is_single_backup
+
+
+class BackupFile:
+    def __init__(self, identifier: str, backup_path: str, settings: BackupFileSettings, pre_compress_ext: str, override_file_name: str = None):
+        self.identifier = identifier
+        self.backup_path = backup_path
+        self.settings = settings
+        self.pre_compress_ext = pre_compress_ext
+        self.override_file_name = override_file_name
+        self._file_name_without_ext = None
+
+    @property
+    def prefix(self):
+        if self.settings.use_identifier_as_perfix:
+            return self.identifier
+        return self.settings.prefix
+
+    @property
+    def extension(self):
+        if self.settings.use_compression:
+            return "{}.gz".format(self.pre_compress_ext)
+        return self.pre_compress_ext
+
+    @property
+    def file_name_without_extension(self):
+        if not self._file_name_without_ext:
+            if self.override_file_name:
+                self._file_name_without_ext = os.path.splitext(self.override_file_name)[0]
+                file_name, ext = os.path.splitext(self._file_name_without_ext)
+                if ext == ".{}".format(self.pre_compress_ext):
+                    self._file_name_without_ext = file_name
+            else:
+                if not self.settings.use_timestamp:
+                    self._file_name_without_ext = self.prefix
+                else:
+                    self._file_name_without_ext = "{}_{}".format(self.prefix, time.strftime("%Y%m%d_%H%M%S"))
+        return self._file_name_without_ext
+
+    @property
+    def file_name(self):
+        if self.override_file_name:
+            return self.override_file_name
+        return "{}.{}".format(self.file_name_without_extension, self.extension)
+
+    @property
+    def file_path(self):
+        return os.path.join(self.backup_path, self.file_name)
+
+    @property
+    def pre_compression_file_path(self):
+        return os.path.join(self.backup_path, "{}.{}".format(self.file_name_without_extension, self.pre_compress_ext))
+
+
+def construct_backup_file(name: str, backup_path: str, settings: BackupFileSettings, pre_compress_ext: str):
+    return BackupFile(name, backup_path, settings, pre_compress_ext)
+
+
+def find_restore_file(backup_filename: str, name: str, backup_path: str, settings: BackupFileSettings, pre_compress_ext: str):
+    backup_file = BackupFile(name, backup_path, settings, pre_compress_ext, backup_filename)
+    if not backup_file.override_file_name:
+        backup_file.override_file_name = fs.find_youngest_file(backup_path, backup_file.prefix, backup_file.extension)
+    return backup_file
+
+
 class DockerCommand(Command):
     def __init__(self, command_string: str, container_name: str, docker_options: List[str],
                  input: str = None, input_path: str = None, output_path: str = None, in_container: bool = False):
@@ -46,155 +132,148 @@ class DockerCommand(Command):
         return dc
 
 
-class MySqlBRCommand(DockerCommand):
-    def __init__(self, name: str, password: str, mysql_command: str, mysql_options: List[str],
-                 backup_path: str, container_name: str, docker_options: List[str], input_path: str = None,
-                 output_path: str = None):
-        self.mysql_command = mysql_command
+#######################################################################################################################
+# Database Backup/Restore
+#######################################################################################################################
+
+
+class DBBRCommand(DockerCommand):
+    def __init__(self, name: str, db_command: str, backup_path: str, backup_file: BackupFile, container_name: str, docker_options: List[str],
+                 input_path: str = None, output_path: str = None):
         self.name = name
-        self.file_prefix = MySqlBRCommand.default_file_prefix(name)
-        self.file_extension = MySqlBRCommand.default_file_extension()
-        self.backup_file = MySqlBRCommand.default_backup_file(backup_path, name)
+        self.db_command = db_command
+        self.backup_path = backup_path
+        self.backup_file = backup_file
         d_opts = docker_options + ['-i']
-        super().__init__('{} {} -p"{}" {}'.format(mysql_command, " ".join(mysql_options), password, name),
-                         container_name, d_opts, input_path=input_path, output_path=output_path, in_container=True)
+        super().__init__(db_command, container_name, d_opts, input_path=input_path, output_path=output_path, in_container=True)
 
-    @classmethod
-    def default_file_prefix(cls, name):
-        return name
+    @property
+    def backup_file_path(self):
+        return self.backup_file.file_path
 
-    @classmethod
-    def default_file_extension(cls):
-        return 'sql'
+    @property
+    def file_prefix(self):
+        return self.backup_file.prefix
 
-    @classmethod
-    def default_backup_file(cls, backup_path, name):
-        return os.path.join(backup_path, "{}_{}.{}".format(MySqlBRCommand.default_file_prefix(name),
-                                                           time.strftime("%Y%m%d_%H%M%S"),
-                                                           MySqlBRCommand.default_file_extension()))
+    @property
+    def file_extension(self):
+        return self.backup_file.extension
+
+    def friendly_str(self):
+        return "DB BR Command for {}".format(self.name)
+
+    def _run_backup(self, log: logging.Logger):
+        if not super().run(log):
+            return False
+        if self.backup_file.settings.use_compression:
+            return compress_file(self.output_path, log)
+        return True
+
+    def _run_restore(self, log: logging.Logger):
+        if self.backup_file.settings.use_compression:
+            if not decompress_file(self.backup_file_path, log):
+                return False
+        was_restore_successful = super().run(log)
+        if self.backup_file.settings.use_compression:
+            if not compress_file(self.input_path, log):
+                return False
+        return was_restore_successful
+
+    def run(self, log: logging.Logger):
+        if self.input_path and self.output_path:
+            log.critical("DBBRCommand: input_path and output_path both provided, this is not supported; {}".format(
+                self.db_command))
+            return False
+        if not self.input_path and not self.output_path:
+            log.critical("DBBRCommand: input_path nor output_path provided, this is not supported; {}".format(
+                self.db_command))
+            return False
+        if self.output_path:
+            return self._run_backup(log)
+        if self.input_path:
+            return self._run_restore(log)
+        return False  # will never be hit
+
+
+class MySqlBRCommand(DBBRCommand):
+    def __init__(self, name: str, password: str, mysql_command: str, mysql_options: List[str],
+                 backup_path: str, sql_backup_file: BackupFile, container_name: str, docker_options: List[str],
+                 input_path: str = None, output_path: str = None):
+        self.mysql_command = mysql_command
+        super().__init__(name, '{} {} -p"{}" {}'.format(mysql_command, " ".join(mysql_options), password, name), backup_path,
+                         sql_backup_file, container_name, docker_options, input_path=input_path, output_path=output_path)
 
     def friendly_str(self):
         return "{} {}".format(self.mysql_command, self.name)
 
 
 class MysqlBackupCommand(MySqlBRCommand):
-    def __init__(self, name: str, password: str, backup_path: str, container_name: str, docker_options: List[str]):
-        super().__init__(name, password, 'mysqldump', ['--single-transaction'], backup_path, container_name,
-                         docker_options, output_path=MySqlBRCommand.default_backup_file(backup_path, name))
+    def __init__(self, name: str, password: str, backup_path: str, settings: BackupFileSettings, container_name: str, docker_options: List[str]):
+        sql_backup_file = construct_backup_file(name, backup_path, settings, 'sql')
+        super().__init__(name, password, 'mysqldump', ['--single-transaction'], backup_path, sql_backup_file, container_name,
+                         docker_options, output_path=sql_backup_file.pre_compression_file_path)
 
 
 class MysqlRestoreCommand(MySqlBRCommand):
-    def __init__(self, name: str, password: str, backup_path: str, container_name: str, docker_options: List[str],
+    def __init__(self, name: str, password: str, backup_path: str, settings: BackupFileSettings, container_name: str, docker_options: List[str],
                  backup_filename: str = None):
-        backup_filename = fs.find_youngest_file(backup_path, MySqlBRCommand.default_file_prefix(name),
-                                                MySqlBRCommand.default_file_extension()) if not backup_filename else backup_filename
-        super().__init__(name, password, 'mysql', [], backup_path, container_name, docker_options,
-                         input_path=os.path.join(backup_path, backup_filename))
-        self.backup_file = os.path.join(backup_path, backup_filename)
+        sql_backup_file = find_restore_file(backup_filename, name, backup_path, settings, 'sql')
+        super().__init__(name, password, 'mysql', [], backup_path, sql_backup_file, container_name, docker_options,
+                         input_path=sql_backup_file.pre_compression_file_path)
 
 
-class PostgresBRCommand(DockerCommand):
+class PostgresBRCommand(DBBRCommand):
     def __init__(self, name: str, postgres_command: str, postgres_options: List[str], backup_path: str,
-                 container_name: str, docker_options: List[str], user: str = None, password: str = None,
+                 sql_backup_file: BackupFile, container_name: str, docker_options: List[str], user: str = None, password: str = None,
                  input_path: str = None, output_path: str = None):
         self.postgres_command = postgres_command
-        self.name = name
         # TODO: support using 'password'
         p_opts = postgres_options + ['-U', user] if user else postgres_options
-        self.file_prefix = PostgresBRCommand.default_file_prefix(name)
-        self.file_extension = PostgresBRCommand.default_file_extension()
-        self.backup_file = PostgresBRCommand.default_backup_file(backup_path, name)
-        d_opts = docker_options + ['-i']
-        super().__init__('{} {}'.format(postgres_command, " ".join(p_opts)), container_name, d_opts,
-                         input_path=input_path, output_path=output_path, in_container=True)
-
-    @classmethod
-    def default_file_prefix(cls, name):
-        return name
-
-    @classmethod
-    def default_file_extension(cls):
-        return 'sql'
-
-    @classmethod
-    def default_backup_file(cls, backup_path, name):
-        return os.path.join(backup_path, "{}_{}.{}".format(PostgresBRCommand.default_file_prefix(name),
-                                                           time.strftime("%Y%m%d_%H%M%S"),
-                                                           PostgresBRCommand.default_file_extension()))
+        super().__init__(name, '{} {}'.format(postgres_command, " ".join(p_opts)), backup_path, sql_backup_file, container_name, docker_options,
+                         input_path=input_path, output_path=output_path)
 
     def friendly_str(self):
         return "{} {}".format(self.postgres_command, self.name)
 
 
 class PostgresBackupCommand(PostgresBRCommand):
-    def __init__(self, name: str, backup_path: str, container_name: str, docker_options: List[str], user: str = None,
+    def __init__(self, name: str, backup_path: str, settings: BackupFileSettings, container_name: str, docker_options: List[str], user: str = None,
                  password: str = None, dump_all: bool = False):
         postgres_command = 'pg_dump'
         postgres_options = ['-d', name]
         if dump_all:
             postgres_command = 'pg_dumpall'
             postgres_options = []
-        super().__init__(name, postgres_command, postgres_options, backup_path, container_name, docker_options, user,
-                         password,
-                         output_path=PostgresBRCommand.default_backup_file(backup_path, name))
+        sql_backup_file = construct_backup_file(name, backup_path, settings, 'sql')
+        super().__init__(name, postgres_command, postgres_options, backup_path, sql_backup_file, container_name, docker_options, user,
+                         password, output_path=sql_backup_file.pre_compression_file_path)
 
 
 class PostgresRestoreCommand(PostgresBRCommand):
-    def __init__(self, name: str, backup_path: str, container_name: str, docker_options: List[str], user: str,
+    def __init__(self, name: str, backup_path: str, settings: BackupFileSettings, container_name: str, docker_options: List[str], user: str,
                  password: str, restore_all: bool = False, backup_filename: str = None):
-        backup_filename = fs.find_youngest_file(backup_path, PostgresBRCommand.default_file_prefix(name),
-                                                PostgresBRCommand.default_file_extension()) if not backup_filename else backup_filename
+        sql_backup_file = find_restore_file(backup_filename, name, backup_path, settings, 'sql')
         super().__init__(name, 'psql', ['-d', 'postgres'] if restore_all else ['-d', name], backup_path,
-                         container_name, docker_options, user, password,
-                         input_path=os.path.join(backup_path, backup_filename))
-        self.backup_file = os.path.join(backup_path, backup_filename)
+                         sql_backup_file, container_name, docker_options, user, password,
+                         input_path=sql_backup_file.pre_compression_file_path)
 
 
-class TarBackupSettings:
-    def __init__(self, is_single_backup: bool, prefix: str = None, force_timestamp: bool = None):
-        self.is_single_backup = is_single_backup
-        self.prefix = prefix
-        self.force_timestamp = force_timestamp
-
-    @property
-    def use_identifier_as_perfix(self):
-        return self.prefix is None
-
-    @property
-    def use_timestamp(self):
-        return self.force_timestamp or not self.is_single_backup
+#######################################################################################################################
+# Directory Backup/Restore
+#######################################################################################################################
 
 
-class DockerTarBuilder:
-    def __init__(self, identifier: str, source_dir_in_container: str, dest_dir_in_container: str, dest_dir_on_host: str, settings: TarBackupSettings, override_file_name: str = None):
-        self.identifier = identifier
+class TarBackupSettings(BackupFileSettings):
+    def __init__(self, is_single_backup: bool, prefix: str = None, force_timestamp: bool = None, use_compression: bool = True):
+        super().__init__(is_single_backup, prefix, force_timestamp, use_compression)
+
+
+class BackupTarFile(BackupFile):
+    def __init__(self, identifier: str, source_dir_in_container: str, dest_dir_in_container: str, dest_dir_on_host: str, settings: TarBackupSettings, backup_path: str, override_file_name: str = None):
         self.source_dir_in_container = source_dir_in_container
         self.dest_dir_in_container = dest_dir_in_container
         self.dest_dir_on_host = dest_dir_on_host
-        self.settings = settings
-        self.override_file_name = override_file_name
-        self._file_name = None
-
-    @property
-    def prefix(self):
-        if self.settings.use_identifier_as_perfix:
-            return self.identifier
-        return self.settings.prefix
-
-    @property
-    def extension(self):
-        return 'tar.gz'
-
-    @property
-    def file_name(self):
-        if self.override_file_name:
-            return self.override_file_name
-        if not self._file_name:
-            if not self.settings.use_timestamp:
-                self._file_name = "{}.{}".format(self.prefix, self.extension)
-            else:
-                self._file_name = "{}_{}.{}".format(self.prefix, time.strftime("%Y%m%d_%H%M%S"), self.extension)
-        return self._file_name
+        super().__init__(identifier, backup_path, settings, 'tar', override_file_name)
 
     @property
     def container_file_path(self):
@@ -213,12 +292,15 @@ class DockerTarBuilder:
         return "tar -xzf {}".format(self.container_file_path)
 
 
-def construct_create_tar_builder(directory: str, container_dir: str, host_tmp_dir: str, settings: TarBackupSettings):
-    return DockerTarBuilder(os.path.basename(directory), directory, container_dir, host_tmp_dir, settings)
+def construct_backup_tar_file_for_create(directory: str, container_dir: str, host_tmp_dir: str, settings: TarBackupSettings, backup_path: str):
+    return BackupTarFile(os.path.basename(directory), directory, container_dir, host_tmp_dir, settings, backup_path)
 
 
-def construct_extract_tar_builder(tar_name: str, directory: str, container_dir: str, host_tmp_dir: str, settings: TarBackupSettings):
-    return DockerTarBuilder(os.path.basename(directory), directory, container_dir, host_tmp_dir, settings, tar_name)
+def find_backup_tar_file_for_extract(tar_name: str, directory: str, container_dir: str, host_tmp_dir: str, settings: TarBackupSettings, backup_path: str):
+    backup_tar_file = BackupTarFile(os.path.basename(directory), directory, container_dir, host_tmp_dir, settings, backup_path, tar_name)
+    if not backup_tar_file.override_file_name:
+        backup_tar_file.override_file_name = fs.find_youngest_file(backup_path, backup_tar_file.prefix, backup_tar_file.extension)
+    return backup_tar_file
 
 
 def get_new_host_tmp_dir():
@@ -226,12 +308,12 @@ def get_new_host_tmp_dir():
 
 
 class DirectoryTarCommand(DockerCommand):
-    def __init__(self, directory: str, backup_path: str, tar_builder: DockerTarBuilder, tar_command: str, container_name: str, docker_options: List[str]):
+    def __init__(self, directory: str, backup_path: str, backup_tar_file: BackupTarFile, tar_command: str, container_name: str, docker_options: List[str]):
         self.directory = directory
         self.backup_path = backup_path
-        self.tar_builder = tar_builder
+        self.backup_tar_file = backup_tar_file
 
-        d_opts = docker_options + ['--rm', '-v', "{}:{}".format(self.tar_builder.dest_dir_on_host, DirectoryTarCommand.default_container_dir())]
+        d_opts = docker_options + ['--rm', '-v', "{}:{}".format(self.backup_tar_file.dest_dir_on_host, DirectoryTarCommand.default_container_dir())]
         super().__init__(tar_command, container_name, d_opts)
 
     @classmethod
@@ -239,16 +321,16 @@ class DirectoryTarCommand(DockerCommand):
         return '/abackup'
 
     @property
-    def backup_file(self):
-        return os.path.join(self.backup_path, self.tar_builder.file_name)
+    def backup_file_path(self):
+        return self.backup_tar_file.file_path
 
     @property
     def file_prefix(self):
-        return self.tar_builder.prefix
+        return self.backup_tar_file.prefix
 
     @property
     def file_extension(self):
-        return self.tar_builder.extension
+        return self.backup_tar_file.extension
 
     def friendly_str(self):
         return "tar {}".format(self.directory)
@@ -256,14 +338,16 @@ class DirectoryTarCommand(DockerCommand):
 
 class DirectoryTarBackupCommand(DirectoryTarCommand):
     def __init__(self, directory: str, backup_path: str, tar_settings: TarBackupSettings, container_name: str, docker_options: List[str]):
-        tar_builder = construct_create_tar_builder(directory, DirectoryTarCommand.default_container_dir(), get_new_host_tmp_dir(), tar_settings)
-        super().__init__(directory, backup_path, tar_builder, tar_builder.command_create_str_in_container, container_name, docker_options)
+        backup_tar_file = construct_backup_tar_file_for_create(
+            directory, DirectoryTarCommand.default_container_dir(), get_new_host_tmp_dir(), tar_settings, backup_path)
+        super().__init__(directory, backup_path, backup_tar_file,
+                         backup_tar_file.command_create_str_in_container, container_name, docker_options)
 
     def run(self, log: logging.Logger):
-        os.makedirs(self.tar_builder.dest_dir_on_host)
-        copy_temp_file_from_host_command = Command("cp {} {}".format(self.tar_builder.host_file_path, self.backup_file))
-        delete_temp_file_from_container_command = self.new_command("rm {}".format(self.tar_builder.container_file_path))
-        delete_temp_dir_from_host_command = Command("rm -rf {}".format(self.tar_builder.dest_dir_on_host))
+        os.makedirs(self.backup_tar_file.dest_dir_on_host)
+        copy_temp_file_from_host_command = Command("cp {} {}".format(self.backup_tar_file.host_file_path, self.backup_file_path))
+        delete_temp_file_from_container_command = self.new_command("rm {}".format(self.backup_tar_file.container_file_path))
+        delete_temp_dir_from_host_command = Command("rm -rf {}".format(self.backup_tar_file.dest_dir_on_host))
         return super().run(log) \
             and copy_temp_file_from_host_command.run(log) \
             and delete_temp_file_from_container_command.run(log) \
@@ -273,17 +357,17 @@ class DirectoryTarBackupCommand(DirectoryTarCommand):
 class DirectoryTarRestoreCommand(DirectoryTarCommand):
     def __init__(self, directory: str, backup_path: str, tar_settings: TarBackupSettings, container_name: str, docker_options: List[str],
                  tar_name: str = None):
-        tar_builder = construct_extract_tar_builder(tar_name, directory, DirectoryTarCommand.default_container_dir(), get_new_host_tmp_dir(), tar_settings)
-        if not tar_builder.override_file_name:
-            tar_builder.override_file_name = fs.find_youngest_file(backup_path, tar_builder.prefix, tar_builder.extension)
-        super().__init__(directory, backup_path, tar_builder, tar_builder.command_extract_str_in_container, container_name, docker_options)
+        backup_tar_file = find_backup_tar_file_for_extract(
+            tar_name, directory, DirectoryTarCommand.default_container_dir(), get_new_host_tmp_dir(), tar_settings, backup_path)
+        super().__init__(directory, backup_path, backup_tar_file,
+                         backup_tar_file.command_extract_str_in_container, container_name, docker_options)
 
     def run(self, log: logging.Logger):
-        os.makedirs(self.tar_builder.dest_dir_on_host)
-        copy_backup_file_from_host_command = Command("cp {} {}".format(self.backup_file, self.tar_builder.host_file_path))
-        chmod_temp_file_from_host_command = Command("chmod o+r {}".format(self.tar_builder.host_file_path))
-        delete_temp_file_from_host_command = Command("rm {}".format(self.tar_builder.host_file_path))
-        delete_temp_dir_from_host_command = Command("rm -rf {}".format(self.tar_builder.dest_dir_on_host))
+        os.makedirs(self.backup_tar_file.dest_dir_on_host)
+        copy_backup_file_from_host_command = Command("cp {} {}".format(self.backup_file_path, self.backup_tar_file.host_file_path))
+        chmod_temp_file_from_host_command = Command("chmod o+r {}".format(self.backup_tar_file.host_file_path))
+        delete_temp_file_from_host_command = Command("rm {}".format(self.backup_tar_file.host_file_path))
+        delete_temp_dir_from_host_command = Command("rm -rf {}".format(self.backup_tar_file.dest_dir_on_host))
         return copy_backup_file_from_host_command.run(log) \
             and chmod_temp_file_from_host_command.run(log) \
             and super().run(log) \

--- a/lib/abackup/docker.py
+++ b/lib/abackup/docker.py
@@ -35,7 +35,7 @@ class DockerCommand(Command):
                                                    self.command_string)
             log.info("Running command in the {} container: {}".format(self.container_name, self.friendly_str()))
         else:
-            command = "{} --volumes-from {} {} busybox sh -c '{}'".format(self.docker_command, self.container_name,
+            command = "{} --volumes-from {} {} ubuntu sh -c '{}'".format(self.docker_command, self.container_name,
                                                                           self.formatted_options(), self.command_string)
             log.info("Running command in a busybox container: {}".format(self.friendly_str()))
         return self._run(command, log)
@@ -206,7 +206,7 @@ class DockerTarBuilder:
 
     @property
     def command_create_str_in_container(self):
-        return "tar -czf {} {}".format(self.container_file_path, self.source_dir_in_container)
+        return "tar -cf - {} | gzip --rsyncable > {}".format(self.source_dir_in_container, self.container_file_path)
 
     @property
     def command_extract_str_in_container(self):

--- a/lib/abackup/sync/rsync.py
+++ b/lib/abackup/sync/rsync.py
@@ -131,8 +131,7 @@ def do_rsync(origin: str, destination: str, rsync_options: RsyncOptions, log: lo
         count_regex = re.compile(
             r"Number of regular files transferred:\s+([\d,]+)")
         deleted_regex = re.compile(r"Number of deleted files:\s+([\d,]+)")
-        bytes_regex = re.compile(
-            r"Total transferred file size:\s+([\d,]+)\s+bytes")
+        bytes_regex = re.compile(r"Total bytes sent:\s+([\d,]+)")
         for line in run_out.stdout.split("\n"):
             deleted_files_match = deleted_files_regex.match(line)
             count_match = count_regex.search(line)

--- a/test/abackup/.abackup.yml
+++ b/test/abackup/.abackup.yml
@@ -49,3 +49,10 @@ containers:
     backup:
       version_count: 2
     restore: {}
+
+  test-single-tar:
+    directories:
+      - /data/bar
+    backup:
+      version_count: 1
+    restore: {}

--- a/test/abackup/.abackup.yml
+++ b/test/abackup/.abackup.yml
@@ -47,7 +47,7 @@ containers:
           dump_all: True
           restore_all: True
     backup:
-      version_count: 2
+      version_count: 1
     restore: {}
 
   test-single-tar:

--- a/test/abackup/docker-compose.yml
+++ b/test/abackup/docker-compose.yml
@@ -22,6 +22,14 @@ services:
     environment:
       POSTGRES_PASSWORD: "testpass"
 
+  test_single_tar:
+    image: busybox
+    container_name: test-single-tar
+    command: tail -F anything
+    volumes:
+      - test_single_tar:/data/bar
+
 volumes:
   test_data:
   test_postgres:
+  test_single_tar:

--- a/test/abackup/setup/init_test_container.sh
+++ b/test/abackup/setup/init_test_container.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker-compose up -d test_single_tar
+
+sleep 1

--- a/test/abackup/setup/populate_test_dir.sh
+++ b/test/abackup/setup/populate_test_dir.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker cp test_data/test_dir_baz.txt test-single-tar:/data/bar/

--- a/test/abackup/setup/verify_test_dir.sh
+++ b/test/abackup/setup/verify_test_dir.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+docker cp test-single-tar:/data/bar/test_dir_baz.txt test_data/test_dir_baz_from_container.txt
+diff test_data/test_dir_baz_from_container.txt test_data/test_dir_baz.txt
+rm test_data/test_dir_baz_from_container.txt
+echo PASS

--- a/test/abackup/test_data/test_dir_baz.txt
+++ b/test/abackup/test_data/test_dir_baz.txt
@@ -1,0 +1,6 @@
+asdjbw8q034n qe09234u5r  r
+` 123r;kqwehj f1 `2
+``12 ;lihr 12 `
+`2345jh412
+` bnbnefhfa23481!@#$!@#$
+'


### PR DESCRIPTION
Compress db backups with gzip.

If version_count is 1, keep the backup file the same name; allowing for rsync, or other path based transfer, to do partial file transfer. 

Also, use the '--rsyncable' option for gzip when compressing db backups as well as tar files (directory backups).