### PR TITLE
Copy backup local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,11 @@ __pycache__/
 
 test/**/logs/
 test/**/data/
+test/**/test_data/
 
 test/abackup/.abackup-tmp/
 
 test/abdata/data.yml
 test/absync/sync.yml
+test/absync/sync_pull.yml
+test/absync/.ssh/

--- a/README.md
+++ b/README.md
@@ -171,9 +171,10 @@ owned_data: # optional
     driver_common_settings:
       - type: rsync
         settings:
-          delete: False # optional
-          max_delete: 10 # optional
-          copy_unsafe_links: False # optional
+          delete: False # default
+          max_delete: 10 # default
+          copy_unsafe_links: False # default
+          inplace: False # default
       - type: restic
         settings:
           global_options: # optional
@@ -194,6 +195,15 @@ owned_data: # optional
             remote_name: r1
             options: # optional
               delete: True
+        pre_commands: # optional
+          - command_type: command
+            command_string: "some command to run"
+          - command_type: copy_recent_backup_local_on_target
+            copy_recent_backup_local_on_target_options:
+              abackup_config: /some/path/to/backup.yml
+              project_config: /some/path/to/project/.abackup.yml
+              container: container-name
+              identifier: id
       - sync_name: "bar"
         notify: never # optional
         frequency: "0 1 * * *" # optional

--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ owned_data: # optional
           max_delete: 10 # default
           copy_unsafe_links: False # default
           inplace: False # default
+          no_whole_file: False # default
+          backup: False # default
+          custom_str: "" # optional
       - type: restic
         settings:
           global_options: # optional

--- a/abackup
+++ b/abackup
@@ -10,7 +10,7 @@ from tabulate import tabulate
 
 from abackup import appcron, fs, notifications
 from abackup.backup import Config
-from abackup.backup.backup import perform_backup
+from abackup.backup.backup import perform_backup, perform_get_backups
 from abackup.backup.project import (ProjectConfig,
                                     get_all_backup_files_for_container)
 from abackup.backup.restore import perform_restore
@@ -186,6 +186,30 @@ def restore_command(ctx, container):
         log.info("--- Restore finished.")
     else:
         log.critical('--- Restore failed!')
+        exit(1)
+
+
+@cli.command('get-backups')
+@click.pass_context
+@click.option('--container', help="Container to use. If not specified, all containers for the project are used.")
+@click.option('--most-recent', flag_value=True, help="Only print the most recent backup files.")
+@click.option('--identifier', help="Filter to a specific backup dir/db.")
+def get_backups_command(ctx, container: str, most_recent: bool, identifier: str):
+    """Get backup file paths for a project's containers' data
+    """
+    config = ctx.obj['config']
+    project_name = ctx.obj['project_name']
+    project_config = ctx.obj['project_config']
+    log = ctx.obj['log']
+
+    log.info("--- get-backups {}".format(project_name))
+
+    ret = perform_get_backups(config, project_name, select_containers(container, project_config, log), most_recent, log, identifier)
+
+    if ret:
+        log.info("--- get-backups finished.")
+    else:
+        log.critical("--- get-backups failed!")
         exit(1)
 
 

--- a/absync
+++ b/absync
@@ -5,8 +5,10 @@ import locale
 import os
 import subprocess
 import sys
+from typing import List
 
 from abackup import appcron
+from abackup.prepare.copy import copy_most_recent_backup_file
 from abackup.sync import Config
 from abackup.sync.examine import perform_examine
 from abackup.sync.sync import perform_rsync, perform_auto_sync
@@ -221,6 +223,39 @@ def auto_command(ctx, data_name: str, sync_name: str, sync_type: str, notify: st
         log.info("--- auto sync finished.")
     else:
         log.critical('--- auto sync failed!')
+        exit(1)
+
+
+@cli.command('copy-most-recent')
+@click.pass_context
+@click.option('--overwrite', flag_value=True, help="Overwrite destinations if they exist.")
+@click.argument('stored-name')
+@click.argument('relative-path')
+@click.argument('destinations', nargs=-1)
+def copy_most_recent_command(ctx, overwrite: bool, stored_name: str, relative_path: bool, destinations: List[str]):
+    """Copy most recent backup file of stored data.
+
+    stored-name:   Name of the stored data path.
+    relative-path: Relative path to directory containing backup files.
+    """
+    config = ctx.obj['config']
+    log = ctx.obj['log']
+
+    log.info("--- copy-most-recent {}:{}".format(stored_name, relative_path))
+
+    if stored_name in config.stored_data:
+        stored_path = config.stored_data[stored_name].path
+
+        ret = copy_most_recent_backup_file(os.path.join(stored_path, relative_path), destinations, log, overwrite)
+
+        if ret:
+            log.info("--- copy-most-recent finished.")
+        else:
+            log.critical("--- copy-most-recent failed!")
+            exit(1)
+    else:
+        log.error("{} not present in config!".format(stored_name))
+        log.critical("--- copy-most-recent failed!")
         exit(1)
 
 

--- a/lib/abackup/__init__.py
+++ b/lib/abackup/__init__.py
@@ -1,6 +1,7 @@
 import logging
 import shlex
 import subprocess
+from typing import List
 
 
 class Command:
@@ -59,3 +60,15 @@ class Command:
 
     def run_with_result(self, log: logging.Logger) -> subprocess.CompletedProcess:
         return self._run_with_result(self.command_string, log)
+
+
+class RemoteCommand(Command):
+    def __init__(self, ssh_options: List[str], ssh_connection_string: str, command_string: str, do_not_wrap_command: bool = False,
+                 input: str = None, input_path: str = None, output_path: str = None, universal_newlines: bool = None):
+        ssh_command_list = ['ssh'] + ssh_options + [ssh_connection_string]
+        if do_not_wrap_command:
+            command_string = " ".join(ssh_command_list) + " " + command_string
+        else:
+            command_string = " ".join(ssh_command_list) + " \"bash --login -c '{}'\"".format(command_string)
+
+        super().__init__(command_string, input, input_path, output_path, universal_newlines)

--- a/lib/abackup/backup/project.py
+++ b/lib/abackup/backup/project.py
@@ -9,6 +9,7 @@ from abackup.docker import BackupFileSettings, Command, DockerCommand, Directory
     PostgresRestoreCommand, TarBackupSettings
 
 
+# TODO: replace with build_commands in init
 def build_commands(command_input: List[Any], container_name: str):
     commands = []
     if command_input:

--- a/lib/abackup/docker.py
+++ b/lib/abackup/docker.py
@@ -309,6 +309,7 @@ def get_new_host_tmp_dir():
 
 class DirectoryTarCommand(DockerCommand):
     def __init__(self, directory: str, backup_path: str, backup_tar_file: BackupTarFile, tar_command: str, container_name: str, docker_options: List[str]):
+        self.name = backup_tar_file.identifier
         self.directory = directory
         self.backup_path = backup_path
         self.backup_tar_file = backup_tar_file

--- a/lib/abackup/fs.py
+++ b/lib/abackup/fs.py
@@ -5,6 +5,14 @@ import subprocess
 from enum import Enum, auto
 from typing import List
 
+# TODO: add permissions
+def ensure_dir_exists(path: str):
+    if not os.path.isdir(path):
+        if os.path.exists(path):
+            return False
+    os.makedirs(path)
+    return True
+
 
 def find_files(path: str, prefix: str, extension: str = ''):
     return [filename for filename in next(os.walk(path))[2]

--- a/lib/abackup/fs.py
+++ b/lib/abackup/fs.py
@@ -15,6 +15,8 @@ def ensure_dir_exists(path: str):
 
 
 def find_files(path: str, prefix: str, extension: str = ''):
+    if not os.path.isdir(path):
+        return []
     return [filename for filename in next(os.walk(path))[2]
             if filename.startswith(prefix) and filename.endswith(extension)]
 

--- a/lib/abackup/prepare/copy.py
+++ b/lib/abackup/prepare/copy.py
@@ -1,0 +1,45 @@
+import logging
+import shutil
+
+from pathlib import Path
+from typing import List
+
+
+def copy_most_recent_backup_file(
+    stored_path: bool, destinations: List[str], log: logging.Logger, overwrite: bool = True
+) -> bool:
+    dir = Path(stored_path)
+    if not dir.is_dir():
+        log.error("{} is not a directory!".format(stored_path))
+        return False
+
+    backup_files = [f for f in dir.iterdir() if f.is_file()]
+    if len(backup_files) < 1:
+        log.error("{} is empty!".format(stored_path))
+        return False
+
+    most_recent_backup = max(backup_files, key=lambda f: f.stat().st_ctime)
+
+    status = True
+
+    for dest in destinations:
+        p = Path(dest)
+        if not p.is_absolute():
+            p = dir / p
+        if p.exists():
+            if p.is_file():
+                if overwrite:
+                    log.info("overwritting {}".format(str(p)))
+                else:
+                    log.info("skipping overwrite of {}".format(str(p)))
+                    continue
+            else:
+                log.error("path exists and is not a file, not sure how to proceed: {}".format(str(p)))
+                status = False
+                continue
+
+        log.info("copying most recent backup {} -> {}".format(most_recent_backup, str(p)))
+        shutil.copyfile(most_recent_backup, str(p))
+        # TODO: handle error cases
+
+    return status

--- a/lib/abackup/prepare/rsync.py
+++ b/lib/abackup/prepare/rsync.py
@@ -1,0 +1,97 @@
+import functools
+import os
+import logging
+from typing import Any, Dict
+
+from abackup import RemoteCommand
+from abackup.backup import Config as BackupConfig
+from abackup.backup.backup import get_backups
+from abackup.backup.project import Container, ProjectConfig
+from abackup.sync import Remote
+
+
+def get_recent_local_backup(
+    backup_config: BackupConfig, project_name: str, container: Container, identifier: str, log: logging.Logger
+):
+    backups = get_backups(backup_config, project_name, [container], True, log, identifier)
+    if len(backups) > 1:
+        log.error("too many backup files found: {}".format(",".join(backups)))
+        return None
+    elif len(backups) == 0:
+        log.error("no backup file found!")
+        return None
+    return backups[0]
+
+
+class CopyRecentBackupOptions:
+    def __init__(
+        self,
+        abackup_config: str,
+        project_config: str,
+        container: str,
+        identifier: str,
+        pull: bool = False,
+    ):
+        self.abackup_config = abackup_config
+        self.project_config = project_config
+        self.container = container
+        self.identifier = identifier
+        self.pull = pull
+
+
+def construct_copy_recent_backup_command(
+    copy_options: CopyRecentBackupOptions,
+    data_name: str,
+    sync_root: str,
+    absync_options: str,
+    remote: Remote,
+    log: logging.Logger,
+):
+    backup_config = BackupConfig(copy_options.abackup_config, True, False, "absync::prepare")
+    project_config = ProjectConfig(copy_options.project_config)
+
+    backup_path = get_recent_local_backup(
+        backup_config,
+        os.path.basename(os.path.dirname(copy_options.project_config)),
+        project_config.container(copy_options.container),
+        copy_options.identifier,
+        log,
+    )
+
+    if not backup_path:
+        log.error("cannot copy recent backup!")
+        return None
+
+    backup_name = os.path.basename(backup_path)
+    relative_path = os.path.relpath(os.path.dirname(backup_path), os.path.dirname(sync_root))
+
+    absync_command = "absync {} copy-most-recent {} {} {}".format(absync_options, data_name, relative_path, backup_name)
+
+    return RemoteCommand(remote.ssh_options(), remote.connection_string(), absync_command, universal_newlines=True)
+
+
+def construct_commands(
+    command_type: str,
+    command_options: Dict[str, Any],
+    log: logging.Logger,
+    data_name: str,
+    sync_root: str,
+    absync_options: str,
+    remote: Remote,
+):
+    if command_type != "copy_recent_backup_local_on_target":
+        return None
+    return construct_copy_recent_backup_command(
+        CopyRecentBackupOptions(**command_options), data_name, sync_root, absync_options, remote, log
+    )
+
+
+def construct_commands_wrapper(
+    data_name: str,
+    sync_root: str,
+    absync_options: str,
+    remote: Remote,
+):
+    return functools.partial(
+        construct_commands, data_name=data_name, sync_root=sync_root, absync_options=absync_options, remote=remote
+    )

--- a/lib/abackup/sync/rsync.py
+++ b/lib/abackup/sync/rsync.py
@@ -85,16 +85,7 @@ def get_stored_path_from_remote(stored_data_name: str, remote: Remote, absync_op
 def do_rsync(origin: str, destination: str, rsync_options: RsyncOptions, log: logging.Logger, sync_name: str = 'manual',
              sync_type: str = 'manual', remote: Remote = None, pull: bool = False):
     command_list = ['rsync', '-az', '--stats', '--info=del', '--info=name']
-    if rsync_options.delete:
-        if rsync_options.max_delete:
-            command_list.extend(
-                ['--delete', "--max-delete={}".format(rsync_options.max_delete)])
-        else:
-            command_list.append('--delete')
-    if rsync_options.copy_unsafe_links:
-        command_list.append('--copy-unsafe-links')
-    if rsync_options.inplace:
-        command_list.extend(['--inplace', '--no-whole-file'])
+    command_list.extend(rsync_options.options_list())
     if remote:
         if remote.ssh_options():
             command_list.extend(

--- a/test/absync/run_tests.sh
+++ b/test/absync/run_tests.sh
@@ -40,14 +40,14 @@ echo
 echo "################################################"
 echo "    stored-path"
 echo
-absync --config sync.yml stored-path stored1
+absync --debug --config sync.yml stored-path stored1
 echo
 
 
 echo "################################################"
 echo "    auto"
 echo
-absync --config sync.yml auto --healthchecks || die 'Check failed!' $?
+absync --debug --config sync.yml auto --healthchecks || die 'Check failed!' $?
 absync --config sync.yml examine
 echo
 


### PR DESCRIPTION
This change is to reduce the amount of data transferred with absync:

1. Adds the option to enable `--inplace` with `--no-whole-file` rsync options by setting `inplace: True` in rsync driver options.
2. Adds a pre_commands option to allow running commands before rsync:
   - copy_recent_backup_local_on_target:  this allows, on the remote, copying a previous backup to the new backup that is about to be copied. This allows rsync to use block-based diffs, if used in conjunction with inplace. This is useful if you are versioning your backups (the backup files have timestamps in their names).